### PR TITLE
Macros

### DIFF
--- a/examples/macros_term.rs
+++ b/examples/macros_term.rs
@@ -18,7 +18,7 @@ pub fn main() {
 	term_writeln!(lock; "just term: " [red]("{} #{} {}!", str_hello, value, str_world)
 		[reset] ("{}", 42) [bg=x]("XxX"));
 	
-	term_writeln!(lock lock; "lock term: ", [red],("{} #{} {}!", str_hello, 2, 1)
+	term_writeln!(lock lock; "lock term: " [red]("{} #{} {}!", str_hello, 2, 1)
 		[reset] ("{}", 42) [bg=x]("XxX"));
 	
 	let term = lock;
@@ -53,24 +53,14 @@ pub fn main() {
 	);
 	term_writeln!( term; );
 	
-	// Some primitive syntax without brackets
-	term_write!(term; [red] "red");
-	term_write!(term; [blue] "blue" [green] "green" [reset] "reset");
-	term_write!(term; ,,;,;; " ");
-	term_write!(term; [blue] "blue" [#green] "#gr" [!fg] "!fg" [!bg] "!bg" );
-	term_write!(term; ;;;,;, " ");
-	term_write!(term; [bold] "bold" [underline] "uline" [red] "red"
-		[!bold] "!bold" [!sty] "!sty" );
-	term_writeln!(term);
-	
 	// Some primitive syntax with brackets
 	term_write!(term; [red] ("red"));
 	term_write!(term; [blue] ("blue") [green] ("green") [reset] ("reset"));
-	term_write!(term; ,,;,;; (" "));
+	term_write!(term; (" "));
 	term_write!(term; [blue] ("blue") [#green] ("#gr") [!fg] ("!fg") [!bg] ("!bg") );
-	term_write!(term; ;;;,;, (" "));
+	term_write!(term; " ");
 	term_write!(term; [bold] ("bold") [underline] ("uline") [red] ("red")
-		[!bold] ("!bold") [!sty] ("!sty") );
+		[!bold] ("!bold") [!style] ("!style") );
 	term_writeln!(term);
 	
 	// Printing
@@ -104,7 +94,7 @@ pub fn main() {
 	term_write!(term; " "
 		[bold] [underline] [red] [#green] "def" [!bg] "!bg");
 	term_writeln!(term; " "
-		[bold] [underline] [red] [#green] "def" [!sty] "!sty");
+		[bold] [underline] [red] [#green] "def" [!style] "!style");
 	
 	// Stuff
 	let theme = mortal::Theme{
@@ -133,11 +123,6 @@ pub fn main() {
 	term_write!(term; [fg=mortal::Color::Green] (:a));
 	term_write!(term; [fg=c2] (?a));
 	term_writeln!(term);
-	term_write!(term; ,,;;;7,,;;;,;42,;;;1;,;,,;);
-	term_writeln!(term);
-	
-	//term.refresh().unwrap();
-	//term.wait_event(Some(std::time::Duration::from_millis(900))).unwrap();
 	
 }
 

--- a/examples/macros_term.rs
+++ b/examples/macros_term.rs
@@ -16,9 +16,9 @@ pub fn main() {
 	
 	// Initial examples, locking, and 'lock' ambiguity tests
 	term_writeln!(lock; "just term: " [red]("{} #{} {}!", str_hello, value, str_world)
-		reset ("{}", 42) [bg=x]("XxX"));
+		[reset] ("{}", 42) [bg=x]("XxX"));
 	
-	term_writeln!(lock lock; "lock term: ", red,("{} #{} {}!", str_hello, 2, 1)
+	term_writeln!(lock lock; "lock term: ", [red],("{} #{} {}!", str_hello, 2, 1)
 		[reset] ("{}", 42) [bg=x]("XxX"));
 	
 	let term = lock;
@@ -27,14 +27,14 @@ pub fn main() {
 	// this examples shows that the macro-local guard does not interfere with
 	// the surrounding scope.
 	let lock = 420;
-	term_writeln!(lock term; "lock again term: " bold red("#{}!", lock)
-		reset (" {}", 42));
+	term_writeln!(lock term; "lock again term: " [ bold ] [red]("#{}!", lock)
+		[reset] (" {}", 42));
 	
 	{
 		let mut guard = term.lock_write().unwrap();
 		
-		term_writeln!(guard; "just guard: " red ("{} #{} {}!", str_hello, value, lock)
-			reset ("{}", 42) [bg=x]("XxX"));
+		term_writeln!(guard; "just guard: " [red] ("{} #{} {}!", str_hello, value, lock)
+			[reset] ("{}", 42) [bg=x]("XxX"));
 		
 		// Would deadlock at run time, because of it is already locked:
 		//term_writeln!(lock term; "lock guard: " red("{} #{} {}!", str_hello, 2, 1)
@@ -54,13 +54,13 @@ pub fn main() {
 	term_writeln!( term; );
 	
 	// Some primitive syntax without brackets
-	term_write!(term; red "red");
-	term_write!(term; blue "blue" green "green" reset "reset");
+	term_write!(term; [red] "red");
+	term_write!(term; [blue] "blue" [green] "green" [reset] "reset");
 	term_write!(term; ,,;,;; " ");
-	term_write!(term; blue "blue" #green "#gr" !fg "!fg" !bg "!bg" );
+	term_write!(term; [blue] "blue" [#green] "#gr" [!fg] "!fg" [!bg] "!bg" );
 	term_write!(term; ;;;,;, " ");
-	term_write!(term; bold "bold" underline "uline" red "red"
-		!bold "!bold" !sty "!sty" );
+	term_write!(term; [bold] "bold" [underline] "uline" [red] "red"
+		[!bold] "!bold" [!sty] "!sty" );
 	term_writeln!(term);
 	
 	// Some primitive syntax with brackets
@@ -83,40 +83,40 @@ pub fn main() {
 	term_writeln!(term);
 	
 	// All colors
-	term_write!(term; black "black" blue "blue" cyan "cyan" green "green"
-		magenta "magenta" red "red" white "white" yellow "yellow");
+	term_write!(term; [black] "black" [blue] "blue" [cyan] "cyan" [green] "green"
+		[magenta] "magenta" [red] "red" [white] "white" [yellow] "yellow");
 	term_write!(term; " - ");
-	term_write!(term; #black "black" #blue "blue" #cyan "cyan" #green "green"
-		#magenta "magenta" #red "red" #white "white" #yellow "yellow");
+	term_write!(term; [#black] "black" [#blue] "blue" [#cyan] "cyan" [#green] "green"
+		[#magenta] "magenta" [#red] "red" [#white] "white" [#yellow] "yellow");
 	term_writeln!(term);
 	
 	// All styles
 	term_write!(term;
-		bold "bold" underline "uline" reverse "rev" italic "italic" " - "
-		!bold "!bold" !reverse "!rev" !italic "!italic" !underline "!uline");
+		[bold] "bold" [underline] "uline" [reverse] "rev" [italic] "italic" " - "
+		[!bold] "!bold" [!reverse] "!rev" [!italic] "!italic" [!underline] "!uline");
 	term_writeln!(term);
 	
 	// Resets
 	term_write!(term;
-		bold underline red #green "def" reset "reset");
+		[bold] [underline] [red] [#green] "def" [reset] "reset");
 	term_write!(term; " "
-		bold underline red #green "def" !fg "!fg");
+		[bold] [underline] [red] [#green] "def" [!fg] "!fg");
 	term_write!(term; " "
-		bold underline red #green "def" !bg "!bg");
+		[bold] [underline] [red] [#green] "def" [!bg] "!bg");
 	term_writeln!(term; " "
-		bold underline red #green "def" !sty "!sty");
+		[bold] [underline] [red] [#green] "def" [!sty] "!sty");
 	
 	// Stuff
 	let theme = mortal::Theme{
 		fg:Some(mortal::Color::Magenta), .. mortal::Theme::default()
 	};
-	term_write!(term; [=theme] "xae" bold ("s{}t", " Hi "));
-	term_write!(term; [fg = mortal::Color::Red] "xae" bold ("s{}t", " Hi "));
+	term_write!(term; [=theme] "xae" [bold] ("s{}t", " Hi "));
+	term_write!(term; [fg = mortal::Color::Red] "xae" [bold] ("s{}t", " Hi "));
 	term_writeln!(term);
 	for i in 0..=1 {
 		term_write!(term; [fg = 
 			if i == 0 {mortal::Color::Red} else {mortal::Color::Blue}]
-		 "Colo" bold ("{}", i));
+		 "Colo" [bold] ("{}", i));
 	}
 	term_writeln!(term);
 	let th = theme.clone();

--- a/examples/macros_term.rs
+++ b/examples/macros_term.rs
@@ -1,0 +1,146 @@
+//! Example of printing to the terminal via macros
+
+
+#[macro_use] extern crate mortal;
+
+use mortal::Terminal;
+use mortal::Screen;
+
+pub fn main() {
+	let lock = Terminal::new().unwrap();
+	let value = 42;
+	let str_hello = "Hello";
+	let x = mortal::Color::Blue;
+	let str_world = "World";
+	let a = "num";
+	
+	// Initial examples, locking, and 'lock' ambiguity tests
+	term_writeln!(lock; "just term: " [red]("{} #{} {}!", str_hello, value, str_world)
+		reset ("{}", 42) [bg=x]("XxX"));
+	
+	term_writeln!(lock lock; "lock term: ", red,("{} #{} {}!", str_hello, 2, 1)
+		[reset] ("{}", 42) [bg=x]("XxX"));
+	
+	let term = lock;
+	
+	// Notice the 'lock' prefix creates a macro-local lock-guard named 'lock',
+	// this examples shows that the macro-local guard does not interfere with
+	// the surrounding scope.
+	let lock = 420;
+	term_writeln!(lock term; "lock again term: " bold red("#{}!", lock)
+		reset (" {}", 42));
+	
+	{
+		let mut guard = term.lock_write().unwrap();
+		
+		term_writeln!(guard; "just guard: " red ("{} #{} {}!", str_hello, value, lock)
+			reset ("{}", 42) [bg=x]("XxX"));
+		
+		// Would deadlock at run time, because of it is already locked:
+		//term_writeln!(lock term; "lock guard: " red("{} #{} {}!", str_hello, 2, 1)
+		//	reset ("{}", 42) [bg=x] ("XxX"));
+		
+		// Would cause compile time error, because the guard has no lock function:
+		//term_writeln!(lock guard; "lock guard: " red("{} #{} {}!", str_hello, 2, 1)
+		//	reset ("{}", 42) [bg=x] ("XxX"));
+	}
+	
+	// Stand alone versions
+	term_write!(term ;);
+	term_write!(  term  );
+	term_writeln!(
+		term
+	);
+	term_writeln!( term; );
+	
+	// Some primitive syntax without brackets
+	term_write!(term; red "red");
+	term_write!(term; blue "blue" green "green" reset "reset");
+	term_write!(term; ,,;,;; " ");
+	term_write!(term; blue "blue" #green "#gr" !fg "!fg" !bg "!bg" );
+	term_write!(term; ;;;,;, " ");
+	term_write!(term; bold "bold" underline "uline" red "red"
+		!bold "!bold" !sty "!sty" );
+	term_writeln!(term);
+	
+	// Some primitive syntax with brackets
+	term_write!(term; [red] ("red"));
+	term_write!(term; [blue] ("blue") [green] ("green") [reset] ("reset"));
+	term_write!(term; ,,;,;; (" "));
+	term_write!(term; [blue] ("blue") [#green] ("#gr") [!fg] ("!fg") [!bg] ("!bg") );
+	term_write!(term; ;;;,;, (" "));
+	term_write!(term; [bold] ("bold") [underline] ("uline") [red] ("red")
+		[!bold] ("!bold") [!sty] ("!sty") );
+	term_writeln!(term);
+	
+	// Printing
+	term_writeln!(term; "St{i}rng" 42 true );
+	term_writeln!(term; (:"St{i}rng") (:42) (:true) (: 40 + 2 == 42) );
+	term_writeln!(term; (?"St{i}rng") (?42) (?true) (? 40 + 2 == 42) );
+	term_writeln!(term; ("Hello Format") );
+	term_writeln!(term; ("{}{}{}{}", "St{i}rng", 42, true, 40 + 2 == 42) );
+	term_writeln!(term; ("{:?}{:?}{:?}{:?}", "St{i}rng", 42, true, 40 + 2 == 42) );
+	term_writeln!(term);
+	
+	// All colors
+	term_write!(term; black "black" blue "blue" cyan "cyan" green "green"
+		magenta "magenta" red "red" white "white" yellow "yellow");
+	term_write!(term; " - ");
+	term_write!(term; #black "black" #blue "blue" #cyan "cyan" #green "green"
+		#magenta "magenta" #red "red" #white "white" #yellow "yellow");
+	term_writeln!(term);
+	
+	// All styles
+	term_write!(term;
+		bold "bold" underline "uline" reverse "rev" italic "italic" " - "
+		!bold "!bold" !reverse "!rev" !italic "!italic" !underline "!uline");
+	term_writeln!(term);
+	
+	// Resets
+	term_write!(term;
+		bold underline red #green "def" reset "reset");
+	term_write!(term; " "
+		bold underline red #green "def" !fg "!fg");
+	term_write!(term; " "
+		bold underline red #green "def" !bg "!bg");
+	term_writeln!(term; " "
+		bold underline red #green "def" !sty "!sty");
+	
+	// Stuff
+	let theme = mortal::macros::Theme{
+		fg:Some(mortal::Color::Magenta), .. mortal::macros::Theme::default()
+	};
+	term_write!(term; [=theme] "xae" bold ("s{}t", " Hi "));
+	term_write!(term; [fg = mortal::Color::Red] "xae" bold ("s{}t", " Hi "));
+	term_writeln!(term);
+	for i in 0..=1 {
+		term_write!(term; [fg = 
+			if i == 0 {mortal::Color::Red} else {mortal::Color::Blue}]
+		 "Colo" bold ("{}", i));
+	}
+	term_writeln!(term);
+	let th = theme.clone();
+	term_write!(term; [=th] ("xae") [bold] ("s{}t", " Hi "));
+	term_writeln!(term);
+	let r = mortal::Color::Red;
+	let b = mortal::Color::Blue;
+	term_write!(term; [fg=r] ("xae") [bg=b] ("s{}t", " Hi "));
+	term_writeln!(term);
+	let c1 = b;
+	let c2 = r;
+	term_write!(term; [fg=c1] ("xae") [bg=c2] ("s{}t", " Hi "));
+	term_writeln!(term);
+	term_write!(term; [fg=mortal::Color::Green] (:a));
+	term_write!(term; [fg=c2] (?a));
+	term_writeln!(term);
+	term_write!(term; ,,;;;7,,;;;,;42,;;;1;,;,,;);
+	term_writeln!(term);
+	
+	//term.refresh().unwrap();
+	//term.wait_event(Some(std::time::Duration::from_millis(900))).unwrap();
+	
+}
+
+
+
+

--- a/examples/macros_term.rs
+++ b/examples/macros_term.rs
@@ -107,8 +107,8 @@ pub fn main() {
 		bold underline red #green "def" !sty "!sty");
 	
 	// Stuff
-	let theme = mortal::macros::Theme{
-		fg:Some(mortal::Color::Magenta), .. mortal::macros::Theme::default()
+	let theme = mortal::Theme{
+		fg:Some(mortal::Color::Magenta), .. mortal::Theme::default()
 	};
 	term_write!(term; [=theme] "xae" bold ("s{}t", " Hi "));
 	term_write!(term; [fg = mortal::Color::Red] "xae" bold ("s{}t", " Hi "));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -53,6 +53,7 @@ pub mod sequence;
 pub mod signal;
 pub mod terminal;
 pub mod util;
+#[macro_use] pub mod macros;
 
 #[cfg(unix)]
 #[path = "unix/mod.rs"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,7 +40,7 @@ pub use screen::{Screen, ScreenReadGuard, ScreenWriteGuard};
 pub use sequence::{FindResult, SequenceMap};
 pub use signal::{Signal, SignalSet};
 pub use terminal::{
-    Color, Cursor, CursorMode, Size, Style,
+    Color, Cursor, CursorMode, Size, Style, Theme,
     Event, Key, MouseEvent, MouseInput, MouseButton, ModifierState,
     PrepareConfig, PrepareState,
     Terminal, TerminalReadGuard, TerminalWriteGuard,

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -34,12 +34,12 @@
 /// - a subtractive style specifier: similar to additive but with a
 ///   leading exclamation mark such as (`!bold`, `!italic`, `!underline`,
 ///   `!reverse`)
-/// - a reset specifier either of `reset`, `!fg`, `!bg`, `!sty`
+/// - a reset specifier either of `reset`, `!fg`, `!bg`, `!style`
 /// - foreground variable: `fg=` plus the name of a variable
 /// - background variable: `bg=` plus the name of a variable
-/// - style variable (overriding): `sty=` plus the name of a variable
-/// - style variable (additive): `sty+=` plus the name of a variable
-/// - style variable (subtractive): `sty-=` plus the name of a variable
+/// - style variable (overriding): `style=` plus the name of a variable
+/// - style variable (additive): `style+=` plus the name of a variable
+/// - style variable (subtractive): `style-=` plus the name of a variable
 /// - theme variable: `=` plus the name of a variable
 ///
 /// The _output instructions_ may be either of the following:
@@ -117,14 +117,6 @@ macro_rules! term_write {
 	// Final rule
 	( $term:ident $( ; )* ) => {
 		$term.clear_attributes();
-	};
-	
-	// Optional , and ; as separators
-	( $term:ident; , $($rest:tt)* ) => {
-		term_write!($term; $($rest)*);
-	};
-	( $term:ident; ; $($rest:tt)* ) => {
-		term_write!($term; $($rest)*);
 	};
 	
 	// Foreground Colors
@@ -244,7 +236,7 @@ macro_rules! term_write {
 		$term.set_bg(None);
 		term_write!($term; $($rest)*);
 	};
-	( $term:ident; [ ! sty ] $($rest:tt)*) => {
+	( $term:ident; [ ! style ] $($rest:tt)*) => {
 		$term.set_style($crate::Style::default());
 		term_write!($term; $($rest)*);
 	};
@@ -258,15 +250,15 @@ macro_rules! term_write {
 		$term.set_fg($e);
 		term_write!($term; $($rest)*);
 	};
-	( $term:ident; [ sty = $e:expr ] $($rest:tt)*) => {
+	( $term:ident; [ style = $e:expr ] $($rest:tt)*) => {
 		$term.set_style($e);
 		term_write!($term; $($rest)*);
 	};
-	( $term:ident; [ sty += $e:expr ] $($rest:tt)*) => {
+	( $term:ident; [ style += $e:expr ] $($rest:tt)*) => {
 		$term.add_style($e);
 		term_write!($term; $($rest)*);
 	};
-	( $term:ident; [ sty -= $e:expr ] $($rest:tt)*) => {
+	( $term:ident; [ style -= $e:expr ] $($rest:tt)*) => {
 		$term.remove_style($e);
 		term_write!($term; $($rest)*);
 	};

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -1,10 +1,105 @@
 //! Provides macros easier printing with colors and styles.
+//!
 //! See: https://github.com/murarth/mortal/issues/7
 
 
 
 
-/// Writes on term
+/// Writes on given terminal using themes.
+///
+/// # Syntax
+///
+/// The base syntax of this macro is:
+///
+/// ```ignore
+/// term_write!( [lock] <terminal> ; [theming|output] ... )
+/// ```
+///
+/// First there is the optional keyword `lock` followed by the identifier
+/// (aka name) of the terminal variable. This variable must be of type
+/// [`Terminal`] or [`TerminalWriteGuard`]. If the type of that
+/// variable is `Terminal` the keyword `lock` may be specified too.
+/// After the terminal variable follow, separated by a semicolon `;`, either
+/// _theme specifications_ or _output instructions_, or multiple of them.
+///
+/// The _theme specifications_ are fenced by square bracket `[ ]`. Within these
+///  is either of the following:
+/// - a foreground color: small caps color name such as (`black`, `blue`,
+///   `cyan`, `green`, `magenta`, `red`, `white`, `yellow`)
+/// - a background color: similar to foreground but with a leading hash `#` such
+///   as (`#black`, `#blue`, `#cyan`, `#green`, `#magenta`, `#red`, `#white`,
+///   `#yellow`)
+/// - an additive style specifier: a small caps style name such as (`bold`,
+///   `italic`, `underline`, `reverse`)
+/// - a subtractive style specifier: similar to additive but with a
+///   leading exclamation mark such as (`!bold`, `!italic`, `!underline`,
+///   `!reverse`)
+/// - a reset specifier either of `reset`, `!fg`, `!bg`, `!sty`
+/// - foreground variable: `fg=` plus the name of a variable
+/// - background variable: `bg=` plus the name of a variable
+/// - style variable: `sty=` plus the name of a variable
+/// - theme variable: `=` plus the name of a variable
+///
+/// The _output instructions_ may be either of the following:
+/// - a literal such as a string `"stuff"` or integer `42`
+/// - a Rust `std::fmt` format string with arguments fenced in
+///   parentheses `( )` such as `("some {}", "text")`
+/// - a `Display` shortcut for the format string `"{}"`, which is an expression
+///   enclosed in parentheses with a leading colon `(: )` such as `(: true)`
+/// - a `Debug` shortcut for the format string `"{:?}"`, which is an expression
+///   enclosed in parentheses with a leading question mark `(? )` such as
+///   `(? true)`. 
+///
+/// [`Terminal`]: ./terminal/struct.Terminal.html
+/// [`TerminalWriteGuard`]: terminal/struct.TerminalWriteGuard.html
+///
+///
+/// # Locking
+///
+/// The terminal write lock will be acquired as required. If the first argument
+/// is of type `TerminalWriteGuard` no locking will be performed since the guard
+/// already holds the lock. If the first argument is of type `Terminal` then
+/// the keyword `lock` may be prefixed. If `lock` is given, then the macro will
+/// acquire the terminal guard before any output and write out all output while
+/// holding it. If the `lock` prefix is not given, each output fragment will lock
+/// the terminal independently, which might lead to actual
+/// fragmented output if there is concurrent thread writing to the terminal.
+///
+/// Notice that if the `TerminalWriteGuard` is held by the current thread,
+/// then this macro must not be called with the `Terminal`. Otherwise a deadlock
+/// will occur.
+///
+///
+/// # Examples
+///
+/// ```
+/// #[macro_use] extern crate mortal;
+/// use mortal::Terminal;
+/// use mortal::Theme;
+/// use mortal::Color;
+/// use mortal::Style;
+///
+/// let term = Terminal::new().unwrap();
+/// // Simple output example
+/// term_write!(term; "Hello world");
+///
+/// // Writing format strings
+/// term_write!(term; ("Number #{}", 42));
+///
+/// // Using keywords
+/// term_write!(term; [blue] "A blue " [bold] "world");
+///
+/// // Using variables
+/// let c = Color::Green;
+/// term_write!(term; "Just " [fg=c] (? c)); // short cut for ("{:?}", c)
+///
+/// // Using themes
+/// let theme = Theme::default().fg(Color::Red).style(Style::BOLD);
+/// term_write!(term; [=theme] "Red and Bold");
+/// ```
+///
+/// Further examples can be found in the examples folder of Mortal.
+///
 #[macro_export]
 macro_rules! term_write {
 	// Lock prefix
@@ -206,7 +301,7 @@ macro_rules! term_write {
 }
 
 
-/// Same as term_write but adds a new line at the end.
+/// Same as term_write macro but adds a new line at the end.
 #[macro_export]
 macro_rules! term_writeln {
 	( lock $term:ident; $( $rest:tt )* ) => {

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -1,21 +1,8 @@
-//! Contains the macros for fancy printing
+//! Provides macros easier printing with colors and styles.
 //! See: https://github.com/murarth/mortal/issues/7
 
 
-use crate::PrepareConfig;
-use crate::Color;
-use crate::Style;
 
-/// A Theme
-#[derive(Clone,Debug,Default)]
-pub struct Theme {
-	/// The style
-    pub style: Style,
-	/// The foreground color
-    pub fg: Option<Color>,
-	/// The background color
-    pub bg: Option<Color>,
-}
 
 /// Writes on term
 #[macro_export]
@@ -188,7 +175,7 @@ macro_rules! term_write {
 	};
 	( $term:ident; [ = $var:expr ] $($rest:tt)*) => {
 		let x = &$var;
-		let th = x as &$crate::macros::Theme;
+		let th = x as &$crate::Theme;
 		$term.set_fg(th.fg).unwrap();
 		$term.set_bg(th.bg).unwrap();
 		$term.set_style(th.style).unwrap();

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -31,123 +31,123 @@ macro_rules! term_write {
 	};
 	
 	// Foreground Colors
-	( $term:ident; black $($rest:tt)*) => {
+	( $term:ident; [ black ] $($rest:tt)*) => {
 		$term.set_fg($crate::Color::Black);
 		term_write!($term; $($rest)*);
 	};
-	( $term:ident; blue $($rest:tt)*) => {
+	( $term:ident; [ blue ] $($rest:tt)*) => {
 		$term.set_fg($crate::Color::Blue);
 		term_write!($term; $($rest)*);
 	};
-	( $term:ident; cyan $($rest:tt)*) => {
+	( $term:ident; [ cyan ] $($rest:tt)*) => {
 		$term.set_fg($crate::Color::Cyan);
 		term_write!($term; $($rest)*);
 	};
-	( $term:ident; green $($rest:tt)*) => {
+	( $term:ident; [ green ] $($rest:tt)*) => {
 		$term.set_fg($crate::Color::Green);
 		term_write!($term; $($rest)*);
 	};
-	( $term:ident; magenta $($rest:tt)*) => {
+	( $term:ident; [ magenta ] $($rest:tt)*) => {
 		$term.set_fg($crate::Color::Magenta);
 		term_write!($term; $($rest)*);
 	};
-	( $term:ident; red $($rest:tt)*) => {
+	( $term:ident; [ red ] $($rest:tt)*) => {
 		$term.set_fg($crate::Color::Red);
 		term_write!($term; $($rest)*);
 	};
-	( $term:ident; white $($rest:tt)*) => {
+	( $term:ident; [ white ] $($rest:tt)*) => {
 		$term.set_fg($crate::Color::White);
 		term_write!($term; $($rest)*);
 	};
-	( $term:ident; yellow $($rest:tt)*) => {
+	( $term:ident; [ yellow ] $($rest:tt)*) => {
 		$term.set_fg($crate::Color::Yellow);
 		term_write!($term; $($rest)*);
 	};
 	
 	// Background Colors
-	( $term:ident; #black $($rest:tt)*) => {
+	( $term:ident; [ # black ] $($rest:tt)*) => {
 		$term.set_bg($crate::Color::Black);
 		term_write!($term; $($rest)*);
 	};
-	( $term:ident; #blue $($rest:tt)*) => {
+	( $term:ident; [ # blue ] $($rest:tt)*) => {
 		$term.set_bg($crate::Color::Blue);
 		term_write!($term; $($rest)*);
 	};
-	( $term:ident; #cyan $($rest:tt)*) => {
+	( $term:ident; [ # cyan ] $($rest:tt)*) => {
 		$term.set_bg($crate::Color::Cyan);
 		term_write!($term; $($rest)*);
 	};
-	( $term:ident; #green $($rest:tt)*) => {
+	( $term:ident; [ # green ] $($rest:tt)*) => {
 		$term.set_bg($crate::Color::Green);
 		term_write!($term; $($rest)*);
 	};
-	( $term:ident; #magenta $($rest:tt)*) => {
+	( $term:ident; [ # magenta ] $($rest:tt)*) => {
 		$term.set_bg($crate::Color::Magenta);
 		term_write!($term; $($rest)*);
 	};
-	( $term:ident; #red $($rest:tt)*) => {
+	( $term:ident; [ # red ] $($rest:tt)*) => {
 		$term.set_bg($crate::Color::Red);
 		term_write!($term; $($rest)*);
 	};
-	( $term:ident; #white $($rest:tt)*) => {
+	( $term:ident; [ # white ] $($rest:tt)*) => {
 		$term.set_bg($crate::Color::White);
 		term_write!($term; $($rest)*);
 	};
-	( $term:ident; #yellow $($rest:tt)*) => {
+	( $term:ident; [ # yellow ] $($rest:tt)*) => {
 		$term.set_bg($crate::Color::Yellow);
 		term_write!($term; $($rest)*);
 	};
 	
 	// Adding Style
-	( $term:ident; bold $($rest:tt)*) => {
+	( $term:ident; [ bold ] $($rest:tt)*) => {
 		$term.add_style($crate::Style::BOLD);
 		term_write!($term; $($rest)*);
 	};
-	( $term:ident; italic $($rest:tt)*) => {
+	( $term:ident; [ italic ] $($rest:tt)*) => {
 		$term.add_style($crate::Style::ITALIC);
 		term_write!($term; $($rest)*);
 	};
-	( $term:ident; reverse $($rest:tt)*) => {
+	( $term:ident; [ reverse ] $($rest:tt)*) => {
 		$term.add_style($crate::Style::REVERSE);
 		term_write!($term; $($rest)*);
 	};
-	( $term:ident; underline $($rest:tt)*) => {
+	( $term:ident; [ underline ] $($rest:tt)*) => {
 		$term.add_style($crate::Style::UNDERLINE);
 		term_write!($term; $($rest)*);
 	};
 	
 	// Removing Style
-	( $term:ident; !bold $($rest:tt)*) => {
+	( $term:ident; [ ! bold ] $($rest:tt)*) => {
 		$term.remove_style($crate::Style::BOLD);
 		term_write!($term; $($rest)*);
 	};
-	( $term:ident; !italic $($rest:tt)*) => {
+	( $term:ident; [ ! italic ] $($rest:tt)*) => {
 		$term.remove_style($crate::Style::ITALIC);
 		term_write!($term; $($rest)*);
 	};
-	( $term:ident; !reverse $($rest:tt)*) => {
+	( $term:ident; [ ! reverse ] $($rest:tt)*) => {
 		$term.remove_style($crate::Style::REVERSE);
 		term_write!($term; $($rest)*);
 	};
-	( $term:ident; !underline $($rest:tt)*) => {
+	( $term:ident; [ ! underline ] $($rest:tt)*) => {
 		$term.remove_style($crate::Style::UNDERLINE);
 		term_write!($term; $($rest)*);
 	};
 	
 	// Resets
-	( $term:ident; reset $($rest:tt)*) => {
+	( $term:ident; [ reset ] $($rest:tt)*) => {
 		$term.clear_attributes();
 		term_write!($term; $($rest)*);
 	};
-	( $term:ident; !fg $($rest:tt)*) => {
+	( $term:ident; [ ! fg ] $($rest:tt)*) => {
 		$term.set_fg(None);
 		term_write!($term; $($rest)*);
 	};
-	( $term:ident; !bg $($rest:tt)*) => {
+	( $term:ident; [ ! bg ] $($rest:tt)*) => {
 		$term.set_bg(None);
 		term_write!($term; $($rest)*);
 	};
-	( $term:ident; !sty $($rest:tt)*) => {
+	( $term:ident; [ ! sty ] $($rest:tt)*) => {
 		$term.set_style($crate::Style::default());
 		term_write!($term; $($rest)*);
 	};
@@ -180,17 +180,6 @@ macro_rules! term_write {
 		$term.set_bg(th.bg).unwrap();
 		$term.set_style(th.style).unwrap();
 		term_write!($term; $($rest)*);
-	};
-	
-	// Unwrap primitive formats from brackets []
-	( $term:ident; [ ! $style:ident ] $($rest:tt)*) => {
-		term_write!($term; ! $style $($rest)*);
-	};
-	( $term:ident; [ # $color:ident ] $($rest:tt)*) => {
-		term_write!($term; # $color $($rest)*);
-	};
-	( $term:ident; [ $prim:ident ] $($rest:tt)*) => {
-		term_write!($term; $prim $($rest)*);
 	};
 	
 	// Single expressing printing

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -1,0 +1,254 @@
+//! Contains the macros for fancy printing
+//! See: https://github.com/murarth/mortal/issues/7
+
+
+use crate::PrepareConfig;
+use crate::Color;
+use crate::Style;
+
+/// A Theme
+#[derive(Clone,Debug,Default)]
+pub struct Theme {
+	/// The style
+    pub style: Style,
+	/// The foreground color
+    pub fg: Option<Color>,
+	/// The background color
+    pub bg: Option<Color>,
+}
+
+/// Writes on term
+#[macro_export]
+macro_rules! term_write {
+	// Lock prefix
+	( lock $term:ident; $($rest:tt)* ) => {
+		// Scoped in order to force unlock at the end.
+		// Otherwise, calling this method twice in row could deadlock.
+		{
+			let mut lock = $term.lock_write().unwrap();
+			term_write!(lock; $( $rest )* );
+		}
+	};
+	
+	// Final rule
+	( $term:ident $( ; )* ) => {
+		$term.clear_attributes();
+	};
+	
+	// Optional , and ; as separators
+	( $term:ident; , $($rest:tt)* ) => {
+		term_write!($term; $($rest)*);
+	};
+	( $term:ident; ; $($rest:tt)* ) => {
+		term_write!($term; $($rest)*);
+	};
+	
+	// Foreground Colors
+	( $term:ident; black $($rest:tt)*) => {
+		$term.set_fg($crate::Color::Black);
+		term_write!($term; $($rest)*);
+	};
+	( $term:ident; blue $($rest:tt)*) => {
+		$term.set_fg($crate::Color::Blue);
+		term_write!($term; $($rest)*);
+	};
+	( $term:ident; cyan $($rest:tt)*) => {
+		$term.set_fg($crate::Color::Cyan);
+		term_write!($term; $($rest)*);
+	};
+	( $term:ident; green $($rest:tt)*) => {
+		$term.set_fg($crate::Color::Green);
+		term_write!($term; $($rest)*);
+	};
+	( $term:ident; magenta $($rest:tt)*) => {
+		$term.set_fg($crate::Color::Magenta);
+		term_write!($term; $($rest)*);
+	};
+	( $term:ident; red $($rest:tt)*) => {
+		$term.set_fg($crate::Color::Red);
+		term_write!($term; $($rest)*);
+	};
+	( $term:ident; white $($rest:tt)*) => {
+		$term.set_fg($crate::Color::White);
+		term_write!($term; $($rest)*);
+	};
+	( $term:ident; yellow $($rest:tt)*) => {
+		$term.set_fg($crate::Color::Yellow);
+		term_write!($term; $($rest)*);
+	};
+	
+	// Background Colors
+	( $term:ident; #black $($rest:tt)*) => {
+		$term.set_bg($crate::Color::Black);
+		term_write!($term; $($rest)*);
+	};
+	( $term:ident; #blue $($rest:tt)*) => {
+		$term.set_bg($crate::Color::Blue);
+		term_write!($term; $($rest)*);
+	};
+	( $term:ident; #cyan $($rest:tt)*) => {
+		$term.set_bg($crate::Color::Cyan);
+		term_write!($term; $($rest)*);
+	};
+	( $term:ident; #green $($rest:tt)*) => {
+		$term.set_bg($crate::Color::Green);
+		term_write!($term; $($rest)*);
+	};
+	( $term:ident; #magenta $($rest:tt)*) => {
+		$term.set_bg($crate::Color::Magenta);
+		term_write!($term; $($rest)*);
+	};
+	( $term:ident; #red $($rest:tt)*) => {
+		$term.set_bg($crate::Color::Red);
+		term_write!($term; $($rest)*);
+	};
+	( $term:ident; #white $($rest:tt)*) => {
+		$term.set_bg($crate::Color::White);
+		term_write!($term; $($rest)*);
+	};
+	( $term:ident; #yellow $($rest:tt)*) => {
+		$term.set_bg($crate::Color::Yellow);
+		term_write!($term; $($rest)*);
+	};
+	
+	// Adding Style
+	( $term:ident; bold $($rest:tt)*) => {
+		$term.add_style($crate::Style::BOLD);
+		term_write!($term; $($rest)*);
+	};
+	( $term:ident; italic $($rest:tt)*) => {
+		$term.add_style($crate::Style::ITALIC);
+		term_write!($term; $($rest)*);
+	};
+	( $term:ident; reverse $($rest:tt)*) => {
+		$term.add_style($crate::Style::REVERSE);
+		term_write!($term; $($rest)*);
+	};
+	( $term:ident; underline $($rest:tt)*) => {
+		$term.add_style($crate::Style::UNDERLINE);
+		term_write!($term; $($rest)*);
+	};
+	
+	// Removing Style
+	( $term:ident; !bold $($rest:tt)*) => {
+		$term.remove_style($crate::Style::BOLD);
+		term_write!($term; $($rest)*);
+	};
+	( $term:ident; !italic $($rest:tt)*) => {
+		$term.remove_style($crate::Style::ITALIC);
+		term_write!($term; $($rest)*);
+	};
+	( $term:ident; !reverse $($rest:tt)*) => {
+		$term.remove_style($crate::Style::REVERSE);
+		term_write!($term; $($rest)*);
+	};
+	( $term:ident; !underline $($rest:tt)*) => {
+		$term.remove_style($crate::Style::UNDERLINE);
+		term_write!($term; $($rest)*);
+	};
+	
+	// Resets
+	( $term:ident; reset $($rest:tt)*) => {
+		$term.clear_attributes();
+		term_write!($term; $($rest)*);
+	};
+	( $term:ident; !fg $($rest:tt)*) => {
+		$term.set_fg(None);
+		term_write!($term; $($rest)*);
+	};
+	( $term:ident; !bg $($rest:tt)*) => {
+		$term.set_bg(None);
+		term_write!($term; $($rest)*);
+	};
+	( $term:ident; !sty $($rest:tt)*) => {
+		$term.set_style($crate::Style::default());
+		term_write!($term; $($rest)*);
+	};
+	
+	// Complex formats
+	( $term:ident; [ fg = $e:expr ] $($rest:tt)*) => {
+		$term.set_fg($e);
+		term_write!($term; $($rest)*);
+	};
+	( $term:ident; [ bg = $e:expr ] $($rest:tt)*) => {
+		$term.set_fg($e);
+		term_write!($term; $($rest)*);
+	};
+	( $term:ident; [ sty = $e:expr ] $($rest:tt)*) => {
+		$term.set_style($e);
+		term_write!($term; $($rest)*);
+	};
+	( $term:ident; [ sty += $e:expr ] $($rest:tt)*) => {
+		$term.add_style($e);
+		term_write!($term; $($rest)*);
+	};
+	( $term:ident; [ sty -= $e:expr ] $($rest:tt)*) => {
+		$term.remove_style($e);
+		term_write!($term; $($rest)*);
+	};
+	( $term:ident; [ = $var:expr ] $($rest:tt)*) => {
+		let x = &$var;
+		let th = x as &$crate::macros::Theme;
+		$term.set_fg(th.fg).unwrap();
+		$term.set_bg(th.bg).unwrap();
+		$term.set_style(th.style).unwrap();
+		term_write!($term; $($rest)*);
+	};
+	
+	// Unwrap primitive formats from brackets []
+	( $term:ident; [ ! $style:ident ] $($rest:tt)*) => {
+		term_write!($term; ! $style $($rest)*);
+	};
+	( $term:ident; [ # $color:ident ] $($rest:tt)*) => {
+		term_write!($term; # $color $($rest)*);
+	};
+	( $term:ident; [ $prim:ident ] $($rest:tt)*) => {
+		term_write!($term; $prim $($rest)*);
+	};
+	
+	// Single expressing printing
+	( $term:ident; (: $e:expr ) $($rest:tt)*) => {
+		write!($term, "{}", $e ).unwrap();
+		term_write!($term; $($rest)*);
+	};
+	( $term:ident; (? $e:expr ) $($rest:tt)*) => {
+		write!($term, "{:?}", $e ).unwrap();
+		term_write!($term; $($rest)*);
+	};
+	
+	// Format printing
+	( $term:ident; ( $( $fmt:tt )+ ) $($rest:tt)*) => {
+		write!($term, $( $fmt )+ ).unwrap();
+		term_write!($term; $($rest)*);
+	};
+	
+	// Literal printing
+	( $term:ident; $s:tt $($rest:tt)*) => {
+		write!($term, "{}", concat!($s)).unwrap();
+		term_write!($term; $($rest)*);
+	};
+}
+
+
+/// Same as term_write but adds a new line at the end.
+#[macro_export]
+macro_rules! term_writeln {
+	( lock $term:ident; $( $rest:tt )* ) => {
+		// Scoped in order to force unlock at the end.
+		// Otherwise, calling this method twice in row could deadlock.
+		{
+			let mut lock = $term.lock_write().unwrap();
+			term_write!(lock; $( $rest )* );
+			writeln!(lock).unwrap();
+		}
+	};
+	( $term:ident $( ; )* ) => {
+		writeln!($term).unwrap();
+	};
+	( $term:ident; $( $rest:tt )* ) => {
+		term_write!($term; $( $rest )* );
+		writeln!($term).unwrap();
+	};
+}
+
+

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -37,7 +37,9 @@
 /// - a reset specifier either of `reset`, `!fg`, `!bg`, `!sty`
 /// - foreground variable: `fg=` plus the name of a variable
 /// - background variable: `bg=` plus the name of a variable
-/// - style variable: `sty=` plus the name of a variable
+/// - style variable (overriding): `sty=` plus the name of a variable
+/// - style variable (additive): `sty+=` plus the name of a variable
+/// - style variable (subtractive): `sty-=` plus the name of a variable
 /// - theme variable: `=` plus the name of a variable
 ///
 /// The _output instructions_ may be either of the following:

--- a/src/terminal.rs
+++ b/src/terminal.rs
@@ -53,6 +53,72 @@ bitflags!{
     }
 }
 
+
+/// Represents a terminal output theme.
+///
+/// A theme consists of a foreground and background color as well as a style.
+#[derive(Clone,Debug,Default)]
+pub struct Theme {
+    /// The foreground color
+    pub fg: Option<Color>,
+    /// The background color
+    pub bg: Option<Color>,
+    /// The style
+    pub style: Style,
+}
+
+impl Theme {
+    /// Creates a new theme with given values.
+    ///
+    /// # Note
+    ///
+    /// In order to create a Theme using default values you might want to use
+    /// `Theme::default()` instead.
+    pub fn new<F,B,S>(fg: F, bg: B, style: S) -> Theme
+        where
+            F: Into<Option<Color>>,
+            B: Into<Option<Color>>,
+            S: Into<Option<Style>> {
+        
+        Theme {
+            fg: fg.into(),
+            bg: bg.into(),
+            style: style.into().unwrap_or_default(),
+        }
+    }
+
+    /// Sets the foreground color on the given Theme and returns the new.
+    pub fn fg<F>(mut self, fg: F) -> Theme
+        where
+            F: Into<Option<Color>> {
+        
+        self.fg = fg.into();
+        
+        self
+    }
+
+    /// Sets the background color on the given Theme and returns the new.
+    pub fn bg<B>(mut self, bg: B) -> Theme
+        where
+            B: Into<Option<Color>> {
+        
+        self.bg = bg.into();
+        
+        self
+    }
+
+    /// Sets the style on the given Theme and returns the new.
+    pub fn style<S>(mut self, style: S) -> Theme
+        where
+            S: Into<Option<Style>> {
+        
+        self.style = style.into().unwrap_or_default();
+        
+        self
+    }
+}
+
+
 /// Represents the cursor position in a terminal device
 #[derive(Copy, Clone, Debug, Default, Eq, PartialEq)]
 pub struct Cursor {


### PR DESCRIPTION
Implement #7: a formatting macro and example demonstrating the usage.

The precise syntax of the implemented macro is defined as follows:

Variable: _any identifier_
Color: `red` | `green` | `blue` | ...
Style: `bold` | `italic` | `reverse` | `underline`
Simple: Color | `#` Color | Style | `!` Style | `reset` | `!fg` | `!bg` | `!style`
Complex: `fg=` Variable | `bg=` Variable | `style=` Variable | `style+=` Variable | `style-=` Variable | `=` Variable
Format: `[` Simple `]` | `[` Complex `]`

Literal: _any string literal or number_
Expr: _any Rust expression_
RFS: _format string literal followed by any number of expressions as arguments_
Text: Literal | `(` RFS `)` | `(:` Expr `)` | `(?` Expr `)`

MacroInput: ( `lock` )? Variable `;` ( Format | Text )* 