### PR TITLE
Update nix to 0.24.1, limit features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ unicode-width = "0.1"
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"
-nix = "0.23.0"
+nix = { version = "0.24.1", default-features = false, features = ["poll", "signal", "term"] }
 terminfo = "0.7"
 
 [target.'cfg(windows)'.dependencies]


### PR DESCRIPTION
This removes memoffset as an indirect dependency, and slightly reduces clean build times.