### PR TITLE
[0.2.4] Update dependency to terminfo 0.8

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mortal"
-version = "0.2.3"
+version = "0.2.4"
 authors = ["Murarth <murarth@gmail.com>"]
 edition = "2018"
 
@@ -24,12 +24,22 @@ unicode-width = "0.1"
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"
 nix = "0.23.0"
-terminfo = "0.7"
+terminfo = "0.8"
 
 [target.'cfg(windows)'.dependencies]
 winapi = { version = "0.3", features = [
-    "consoleapi", "handleapi", "minwindef", "ntdef", "processenv", "synchapi",
-    "winbase", "wincon", "winerror", "winnt", "winuser" ] }
+    "consoleapi",
+    "handleapi",
+    "minwindef",
+    "ntdef",
+    "processenv",
+    "synchapi",
+    "winbase",
+    "wincon",
+    "winerror",
+    "winnt",
+    "winuser",
+] }
 
 [dev-dependencies]
 rand = "0.7"


### PR DESCRIPTION
I'm getting a `warning: the following packages contain code that will be rejected by a future version of Rust: nom v5.1.2`, which is caused by the use of linefeed:

- linefeed 0.6.0 -> mortal 0.2.3 -> terminfo 0.7 -> nom 5

With this update (no code change necessary), the issue should be resolved:

- linefeed 0.6.0 -> mortal 0.2.4 -> terminfo 0.8 -> nom 7
